### PR TITLE
Feat/ET-92 : 스튜디오 상세 조회 (가격탭) - 구현 1

### DIFF
--- a/src/main/generated/com/example/toucheese_be/domain/item/entity/QItem.java
+++ b/src/main/generated/com/example/toucheese_be/domain/item/entity/QItem.java
@@ -30,6 +30,8 @@ public class QItem extends EntityPathBase<Item> {
 
     public final EnumPath<com.example.toucheese_be.domain.item.entity.constant.ItemCategory> itemCategory = createEnum("itemCategory", com.example.toucheese_be.domain.item.entity.constant.ItemCategory.class);
 
+    public final ListPath<ItemOption, QItemOption> itemOptions = this.<ItemOption, QItemOption>createList("itemOptions", ItemOption.class, QItemOption.class, PathInits.DIRECT2);
+
     public final StringPath name = createString("name");
 
     public final NumberPath<Integer> price = createNumber("price", Integer.class);

--- a/src/main/generated/com/example/toucheese_be/domain/studio/entity/QStudio.java
+++ b/src/main/generated/com/example/toucheese_be/domain/studio/entity/QStudio.java
@@ -26,6 +26,8 @@ public class QStudio extends EntityPathBase<Studio> {
 
     public final QConcept concept;
 
+    public final StringPath description = createString("description");
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final ListPath<StudioImage, QStudioImage> images = this.<StudioImage, QStudioImage>createList("images", StudioImage.class, QStudioImage.class, PathInits.DIRECT2);
@@ -37,6 +39,8 @@ public class QStudio extends EntityPathBase<Studio> {
     public final NumberPath<Double> popularity = createNumber("popularity", Double.class);
 
     public final ListPath<Portfolio, QPortfolio> portfolios = this.<Portfolio, QPortfolio>createList("portfolios", Portfolio.class, QPortfolio.class, PathInits.DIRECT2);
+
+    public final ListPath<StudioDutyDate, QStudioDutyDate> studioDutyDates = this.<StudioDutyDate, QStudioDutyDate>createList("studioDutyDates", StudioDutyDate.class, QStudioDutyDate.class, PathInits.DIRECT2);
 
     public QStudio(String variable) {
         this(Studio.class, forVariable(variable), INITS);

--- a/src/main/generated/com/example/toucheese_be/domain/studio/entity/QStudioDutyDate.java
+++ b/src/main/generated/com/example/toucheese_be/domain/studio/entity/QStudioDutyDate.java
@@ -1,0 +1,59 @@
+package com.example.toucheese_be.domain.studio.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QStudioDutyDate is a Querydsl query type for StudioDutyDate
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QStudioDutyDate extends EntityPathBase<StudioDutyDate> {
+
+    private static final long serialVersionUID = 1900185835L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QStudioDutyDate studioDutyDate = new QStudioDutyDate("studioDutyDate");
+
+    public final TimePath<java.time.LocalTime> closeTime = createTime("closeTime", java.time.LocalTime.class);
+
+    public final EnumPath<com.example.toucheese_be.domain.studio.entity.constant.DayType> day = createEnum("day", com.example.toucheese_be.domain.studio.entity.constant.DayType.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final TimePath<java.time.LocalTime> openTime = createTime("openTime", java.time.LocalTime.class);
+
+    public final QStudio studio;
+
+    public final EnumPath<com.example.toucheese_be.domain.studio.entity.constant.DutyType> type = createEnum("type", com.example.toucheese_be.domain.studio.entity.constant.DutyType.class);
+
+    public QStudioDutyDate(String variable) {
+        this(StudioDutyDate.class, forVariable(variable), INITS);
+    }
+
+    public QStudioDutyDate(Path<? extends StudioDutyDate> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QStudioDutyDate(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QStudioDutyDate(PathMetadata metadata, PathInits inits) {
+        this(StudioDutyDate.class, metadata, inits);
+    }
+
+    public QStudioDutyDate(Class<? extends StudioDutyDate> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.studio = inits.isInitialized("studio") ? new QStudio(forProperty("studio"), inits.get("studio")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/example/toucheese_be/domain/user/entity/QUser.java
+++ b/src/main/generated/com/example/toucheese_be/domain/user/entity/QUser.java
@@ -1,0 +1,41 @@
+package com.example.toucheese_be.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -763177903L;
+
+    public static final QUser user = new QUser("user");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath name = createString("name");
+
+    public final StringPath profile_img = createString("profile_img");
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/example/toucheese_be/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/controller/ItemController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ItemController {
     private final ItemService itemService;
 
+
     /**
      * TODO: 스튜디오 상품 상세 조회
      */

--- a/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
@@ -1,5 +1,6 @@
 package com.example.toucheese_be.domain.item.dto;
 
+import com.example.toucheese_be.domain.item.entity.Item;
 import com.example.toucheese_be.domain.item.entity.constant.ItemCategory;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,4 +16,13 @@ public class ItemDto {
     private String itemDescription;
     private Integer reviewCounts;
     private Integer price;
+
+    public static ItemDto fromEntity(Item entity) {
+        return ItemDto.builder()
+                .itemName(entity.getName())
+                .itemDescription(entity.getDescription())
+                .reviewCounts(null)
+                .price(entity.getPrice())
+                .build();
+    }
 }

--- a/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
@@ -1,4 +1,18 @@
-//package com.example.toucheese_be.domain.item.dto;
-//
-//public class ItemDto {
-//}
+package com.example.toucheese_be.domain.item.dto;
+
+import com.example.toucheese_be.domain.item.entity.constant.ItemCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemDto {
+    private String itemName;
+    private String itemDescription;
+    private Integer reviewCounts;
+    private Integer price;
+}

--- a/src/main/java/com/example/toucheese_be/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/repository/ItemRepository.java
@@ -1,7 +1,9 @@
 package com.example.toucheese_be.domain.item.repository;
 
 import com.example.toucheese_be.domain.item.entity.Item;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findByStudioId(Long studioId);
 }

--- a/src/main/java/com/example/toucheese_be/domain/studio/controller/StudioController.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/controller/StudioController.java
@@ -1,6 +1,7 @@
 package com.example.toucheese_be.domain.studio.controller;
 
 import com.example.toucheese_be.domain.studio.dto.ConceptDto;
+import com.example.toucheese_be.domain.studio.dto.StudioInfoDto;
 import com.example.toucheese_be.domain.studio.dto.StudioSearchFilterDto;
 import com.example.toucheese_be.domain.studio.dto.StudioDto;
 import com.example.toucheese_be.domain.studio.service.StudioService;
@@ -51,8 +52,10 @@ public class StudioController {
     /**
      * TODO: 스튜디오 상세 조회 - 가격 탭
      */
-    @GetMapping("/details/{studioId}/items")
-    public void getStudioItems() {}
+    @GetMapping("/{studioId}/items")
+    public ResponseEntity<StudioInfoDto> getStudioItems() {
+        return studioService.getStudioItems();
+    }
 
     /**
      * TODO: 스튜디오 상세 조회 - 리뷰탭

--- a/src/main/java/com/example/toucheese_be/domain/studio/controller/StudioController.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/controller/StudioController.java
@@ -1,6 +1,7 @@
 package com.example.toucheese_be.domain.studio.controller;
 
 import com.example.toucheese_be.domain.studio.dto.ConceptDto;
+import com.example.toucheese_be.domain.studio.dto.StudioDetailDto;
 import com.example.toucheese_be.domain.studio.dto.StudioInfoDto;
 import com.example.toucheese_be.domain.studio.dto.StudioSearchFilterDto;
 import com.example.toucheese_be.domain.studio.dto.StudioDto;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -50,17 +52,20 @@ public class StudioController {
     }
 
     /**
-     * TODO: 스튜디오 상세 조회 - 가격 탭
+     * 스튜디오 상세 조회 - 가격 탭
      */
     @GetMapping("/{studioId}/items")
-    public ResponseEntity<StudioInfoDto> getStudioItems() {
-        return studioService.getStudioItems();
+    public ResponseEntity<StudioDetailDto> getStudioItems(
+            @PathVariable
+            Long studioId
+    ) {
+        return studioService.getStudioItems(studioId);
     }
 
     /**
      * TODO: 스튜디오 상세 조회 - 리뷰탭
      */
-    @GetMapping("/details/{studioId}/reviews")
+    @GetMapping("/{studioId}/reviews")
     public void getStudioReviews() {}
 
     /**

--- a/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioDetailDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioDetailDto.java
@@ -1,0 +1,19 @@
+package com.example.toucheese_be.domain.studio.dto;
+
+import com.example.toucheese_be.domain.item.dto.ItemDto;
+import com.example.toucheese_be.domain.item.entity.constant.ItemCategory;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudioDetailDto {
+    private StudioInfoDto studioInfoDto;
+    private Map<ItemCategory, List<ItemDto>> categorizedItems;
+}

--- a/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioInfoDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioInfoDto.java
@@ -1,6 +1,13 @@
 package com.example.toucheese_be.domain.studio.dto;
 
+import com.example.toucheese_be.domain.studio.entity.Portfolio;
+import com.example.toucheese_be.domain.studio.entity.Studio;
+import com.example.toucheese_be.domain.studio.entity.StudioImage;
+import com.example.toucheese_be.domain.studio.entity.constant.DutyType;
+import com.example.toucheese_be.domain.studio.entity.constant.StudioImageType;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,9 +23,38 @@ public class StudioInfoDto {
     private Long studioId;
     private String studioName;
     private String studioProfile;
-    private List<String> studioBackground;
-    private String popularity;
+    private List<String> studioBackgrounds;
+    private Double popularity;
     private String dutyDate;
     private String address;
     private String studioDescription;
+
+    public static StudioInfoDto fromEntity(Studio entity) {
+        // PROFILE 타입 이미지 필터링
+        String studioProfile = entity.getImages().stream()
+                .filter(image -> image.getType() == StudioImageType.PROFILE)
+                .map(StudioImage::getImageUrl)
+                .findFirst()
+                .orElse(null);
+
+        // BACKGROUND 타입 이미지 필터링
+        List<String> studioBackgrounds = entity.getImages().stream()
+                .filter(image -> image.getType() == StudioImageType.BACKGROUND)
+                .sorted(Comparator.comparingInt(StudioImage::getPosition))
+                .map(StudioImage::getImageUrl)
+                .toList();
+
+        // TODO: 근무 시간에 대한 반환 문자열 처리
+
+        return StudioInfoDto.builder()
+                .studioId(entity.getId())
+                .studioName(entity.getName())
+                .studioProfile(studioProfile)
+                .studioBackgrounds(studioBackgrounds)
+                .popularity(entity.getPopularity())
+                .dutyDate(null)
+                .address(entity.getAddress())
+                .studioDescription(entity.getDescription())
+                .build();
+    }
 }

--- a/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioInfoDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioInfoDto.java
@@ -1,0 +1,24 @@
+package com.example.toucheese_be.domain.studio.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudioInfoDto {
+    private Long studioId;
+    private String studioName;
+    private String studioProfile;
+    private List<String> studioBackground;
+    private String popularity;
+    private String dutyDate;
+    private String address;
+    private String studioDescription;
+}

--- a/src/main/java/com/example/toucheese_be/domain/studio/entity/Studio.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/entity/Studio.java
@@ -40,6 +40,10 @@ public class Studio {
     @Column(length=150)
     private String address;
 
+    // 스튜디오 공지사항
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
     // 컨셉 (여러 스튜디오가 하나의 컨셉에 연결)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "concept_id", nullable = false)

--- a/src/main/java/com/example/toucheese_be/domain/studio/service/StudioService.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/service/StudioService.java
@@ -1,15 +1,24 @@
 package com.example.toucheese_be.domain.studio.service;
 
+import com.example.toucheese_be.domain.item.dto.ItemDto;
+import com.example.toucheese_be.domain.item.entity.Item;
+import com.example.toucheese_be.domain.item.entity.constant.ItemCategory;
+import com.example.toucheese_be.domain.item.repository.ItemRepository;
 import com.example.toucheese_be.domain.studio.dto.ConceptDto;
+import com.example.toucheese_be.domain.studio.dto.StudioDetailDto;
 import com.example.toucheese_be.domain.studio.dto.StudioDto;
+import com.example.toucheese_be.domain.studio.dto.StudioInfoDto;
 import com.example.toucheese_be.domain.studio.dto.StudioSearchFilterDto;
+import com.example.toucheese_be.domain.studio.entity.Studio;
 import com.example.toucheese_be.domain.studio.repository.ConceptRepository;
 import com.example.toucheese_be.domain.studio.repository.StudioRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,6 +26,7 @@ import org.springframework.stereotype.Service;
 public class StudioService {
     private final StudioRepository studioRepository;
     private final ConceptRepository conceptRepository;
+    private final ItemRepository itemRepository;
 
     /**
      * 컨셉 조회
@@ -35,4 +45,33 @@ public class StudioService {
     public Page<StudioDto> getStudiosByConceptFilters(Long conceptId, StudioSearchFilterDto dto, Pageable pageable) {
         return studioRepository.getStudioListWithPages(conceptId, dto, pageable);
     }
+
+    /**
+     * 스튜디오 상세 페이지 조회 - 가격탭
+     */
+    public ResponseEntity<StudioDetailDto> getStudioItems(Long studioId) {
+        // 스튜디오 조회
+        Studio studio = studioRepository.findById(studioId)
+                .orElseThrow(() -> new IllegalArgumentException("스튜디오를 찾을 수 없습니다."));
+
+        // StudioInfoDto 변환
+        StudioInfoDto studioInfoDto = StudioInfoDto.fromEntity(studio);
+
+        // 스튜디오에 해당하는 아이템들을 가져옴
+        List<Item> items = itemRepository.findByStudioId(studioId);
+
+        // ItemCategory별로 아이템을 그룹화
+        Map<ItemCategory, List<ItemDto>> categorizedItems = items.stream()
+                .collect(Collectors.groupingBy(Item::getItemCategory,
+                        Collectors.mapping(ItemDto::fromEntity, Collectors.toList())));
+
+        // StudioDetailDto 반환
+        StudioDetailDto studioDetailDto = StudioDetailDto.builder()
+                .studioInfoDto(studioInfoDto)  // studioInfoDto는 StudioInfoDto.fromEntity()에서 변환됨
+                .categorizedItems(categorizedItems)  // 아이템을 ItemCategory별로 그룹화한 Map
+                .build();
+
+        return ResponseEntity.ok(studioDetailDto);
+    }
+
 }

--- a/src/main/java/com/example/toucheese_be/domain/user/entity/User.java
+++ b/src/main/java/com/example/toucheese_be/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
+@Table(name = "users")
 public class User {
 
     @Id


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 이슈 번호
- ex) #ET-92

### 💡 작업유형
- [x] feature: 신규 기능 추가
- [ ] refactor: 성능 개선 등 리펙토링 및 폴더 구조 정리
- [ ] bug: 버그 수정
- [ ] chores: 변수 이름 or 값, 파일명, 주석 수정, 컨벤션 적용
- [ ] docs: 문서 업데이트(readme, gitignore, PR template 등)

<br>


### 🔑 작업 내역
- 스튜디오 상세 조회 - 가격탭 초기 구현
- `dutyDate` 는 우선 null 로 설정
- DB 데이터 불충분으로 인해 나머지 응답에서 null 인 부분 존재
- PostgreSQL 의 경우 `user` 테이블의 이름을 `users` 로 매핑을 해야 오류가 안나기 때문에 `user` 테이블에 `@Table` 어노테이션으로 `users` 명시
![image](https://github.com/user-attachments/assets/544d0973-7659-4238-a510-0a813c6765d3)


### 📋 체크리스트

- [ ] 내 코드에 오류가 없는지 검토했나요?
- [ ] Merge 하는 브랜치가 올바른가요?
- [ ] 코딩 컨벤션을 어기진 않았했나요?

<br>

### 📝 PR 특이 사항

> PR에서 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br><br>
