### PR TITLE
feat: 스튜디오 조회 가격탭 itemImage 누락 문제 해결

### DIFF
--- a/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
@@ -17,6 +17,7 @@ public class ItemDto {
     private String itemDescription;
     private Integer reviewCounts;
     private Integer price;
+    private String itemImage;
 
     public static ItemDto fromEntity(Item entity) {
         return ItemDto.builder()
@@ -25,6 +26,7 @@ public class ItemDto {
                 .itemDescription(entity.getDescription())
                 .reviewCounts(entity.getItemReview().size())
                 .price(entity.getPrice())
+                .itemImage(entity.getImage())
                 .build();
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 이슈 번호
- ex) #ET-92

### 💡 작업유형
- [ ] feature: 신규 기능 추가
- [ ] refactor: 성능 개선 등 리펙토링 및 폴더 구조 정리
- [ ] bug: 버그 수정
- [ ] chores: 변수 이름 or 값, 파일명, 주석 수정, 컨벤션 적용
- [ ] docs: 문서 업데이트(readme, gitignore, PR template 등)

<br>


### 🔑 작업 내역
- 가격탬에 상품 이미지가 안보이는 문제가 발생
- 원인: `categorizedItems` 에 `itemImage` 가 포함되지 않았기 떄문
- 해결: `ItemDto` 에 `itemImage` 필드 추가

<br>


### 📋 체크리스트

- [ ] 내 코드에 오류가 없는지 검토했나요?
- [ ] Merge 하는 브랜치가 올바른가요?
- [ ] 코딩 컨벤션을 어기진 않았했나요?

<br>

### 📝 PR 특이 사항

> PR에서 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2

<br><br>
