### PR TITLE
Feat/ET-92 : 가격탭 상품 카테고리 해제, 가격 필터링 범위 지정 

### DIFF
--- a/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/dto/ItemDto.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class ItemDto {
     private Long itemId;
     private String itemName;
+    private String itemCategory;
     private String itemDescription;
     private Integer reviewCounts;
     private Integer price;
@@ -23,6 +24,7 @@ public class ItemDto {
         return ItemDto.builder()
                 .itemId(entity.getId())
                 .itemName(entity.getName())
+                .itemCategory(entity.getItemCategory().toString())
                 .itemDescription(entity.getDescription())
                 .reviewCounts(entity.getItemReview().size())
                 .price(entity.getPrice())

--- a/src/main/java/com/example/toucheese_be/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/toucheese_be/domain/item/service/ItemService.java
@@ -13,8 +13,10 @@ import com.example.toucheese_be.domain.studio.dto.StudioDetailDto;
 import com.example.toucheese_be.domain.studio.dto.StudioInfoDto;
 import com.example.toucheese_be.domain.studio.entity.Studio;
 import com.example.toucheese_be.domain.studio.repository.StudioRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -38,18 +40,15 @@ public class ItemService {
 
         // 스튜디오에 해당하는 아이템들을 가져옴
         List<Item> items = itemRepository.findByStudioId(studioId);
-
-        // ItemCategory별로 아이템을 그룹화 (null은 "촬영상품"으로 처리)
-        Map<ItemCategory, List<ItemDto>> categorizedItems = items.stream()
-                .collect(Collectors.groupingBy(
-                        item -> item.getItemCategory() != null ? item.getItemCategory() : ItemCategory.UNKNOWN, // null이면 UNKNOWN
-                        Collectors.mapping(ItemDto::fromEntity, Collectors.toList())
-                ));
+        List<ItemDto> itemDtos = new ArrayList<>();
+        for (Item item : items) {
+            itemDtos.add(ItemDto.fromEntity(item));
+        }
 
         // StudioDetailDto 반환
         StudioDetailDto studioDetailDto = StudioDetailDto.builder()
                 .studioInfoDto(studioInfoDto)  // studioInfoDto는 StudioInfoDto.fromEntity()에서 변환됨
-                .categorizedItems(categorizedItems)  // 아이템을 ItemCategory별로 그룹화한 Map
+                .items(itemDtos)  // 아이템을 ItemCategory별로 그룹화한 Map
                 .build();
 
         return ResponseEntity.ok(studioDetailDto);

--- a/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioDetailDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/dto/StudioDetailDto.java
@@ -15,5 +15,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class StudioDetailDto {
     private StudioInfoDto studioInfoDto;
-    private Map<ItemCategory, List<ItemDto>> categorizedItems;
+    private List<ItemDto> items;
 }

--- a/src/main/java/com/example/toucheese_be/domain/studio/entity/constant/PriceFilter.java
+++ b/src/main/java/com/example/toucheese_be/domain/studio/entity/constant/PriceFilter.java
@@ -4,10 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum PriceFilter {
-    ALL(null, null),
-    BELOW_10(0, 100000),
-    BELOW_20(0, 200000),
-    ABOVE_20(200000, null);
+    BELOW_10(0, 99999),
+    BELOW_20(100000, 199999),
+    ABOVE_20(200000, 1000000);
 
     private final Integer minPrice;
     private final Integer maxPrice;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 이슈 번호
- ex) #ET-92

### 💡 작업유형
- [x] feature: 신규 기능 추가
- [ ] refactor: 성능 개선 등 리펙토링 및 폴더 구조 정리
- [ ] bug: 버그 수정
- [x] chores: 변수 이름 or 값, 파일명, 주석 수정, 컨벤션 적용
- [ ] docs: 문서 업데이트(readme, gitignore, PR template 등)

<br>

### 🔑 작업 내역
- 스튜디오 가격탭 조회의 응답에서 `categorizedItems` 삭제 후 상품 내부로 카테고리 필드를 추가 
- 스튜디오 마다 가장 적은 금액의 프로필촬영 상품을 대표 상품으로 설정
- 가격 필터링 시 기존의 방식에서 범위 (ex. 10만원 이상 ~ 20만원 미만) 형식으로 변경


