### PR TITLE
feat: 관리자 페이지 - 예약 리스트 조회 페이지 네이션, 예약 승인/거절 구현

### DIFF
--- a/src/main/generated/com/example/toucheese_be/domain/auth/user/entity/QUser.java
+++ b/src/main/generated/com/example/toucheese_be/domain/auth/user/entity/QUser.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -24,6 +25,8 @@ public class QUser extends EntityPathBase<User> {
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final StringPath name = createString("name");
+
+    public final ListPath<com.example.toucheese_be.domain.order.entity.Order, com.example.toucheese_be.domain.order.entity.QOrder> orders = this.<com.example.toucheese_be.domain.order.entity.Order, com.example.toucheese_be.domain.order.entity.QOrder>createList("orders", com.example.toucheese_be.domain.order.entity.Order.class, com.example.toucheese_be.domain.order.entity.QOrder.class, PathInits.DIRECT2);
 
     public final StringPath phoneNumber = createString("phoneNumber");
 

--- a/src/main/java/com/example/toucheese_be/domain/auth/admin/controller/AdminController.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/admin/controller/AdminController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,22 +32,26 @@ public class AdminController {
         return adminService.readAllOrders(dto);
     }
 
-    // 관리자 페이지 - 예약 승인
-    @GetMapping("/{orderId}/approve")
-    public void approveOrder(
+    /**
+     * 관리자 페이지 - 예약 승인
+     */
+    @PutMapping("/{orderId}/approve")
+    public ResponseEntity<Boolean> approveOrder(
             @PathVariable
             Long orderId
     ) {
-        adminService.approveOrder(orderId);
+        return adminService.approveOrder(orderId);
     }
 
-    // 관리자 페이지 - 예약 거절
-    @GetMapping("/{orderId}/reject")
-    public void rejectOrder(
+    /**
+     * 관리자 페이지 - 예약 거절
+     */
+    @PutMapping("/{orderId}/reject")
+    public ResponseEntity<Boolean> rejectOrder(
             @PathVariable
             Long orderId
     ) {
-        adminService.rejectOrder(orderId);
+        return adminService.rejectOrder(orderId);
     }
 
 }

--- a/src/main/java/com/example/toucheese_be/domain/auth/admin/controller/AdminController.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/admin/controller/AdminController.java
@@ -3,11 +3,14 @@ package com.example.toucheese_be.domain.auth.admin.controller;
 
 import com.example.toucheese_be.domain.auth.admin.dto.AdminOrderDto;
 import com.example.toucheese_be.domain.auth.admin.service.AdminService;
-import java.util.List;
+import com.example.toucheese_be.domain.studio.dto.PageRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,9 +23,12 @@ public class AdminController {
     /**
      * 관리자 페이지 - 예약 리스트 조회
      */
-    @GetMapping
-    public ResponseEntity<List<AdminOrderDto>> readAllOrders() {
-        return adminService.readAllOrders();
+    @PostMapping
+    public ResponseEntity<Page<AdminOrderDto>> readAllOrders(
+            @RequestBody
+            PageRequestDto dto
+    ) {
+        return adminService.readAllOrders(dto);
     }
 
     // 관리자 페이지 - 예약 승인

--- a/src/main/java/com/example/toucheese_be/domain/auth/admin/dto/AdminOrderItemDto.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/admin/dto/AdminOrderItemDto.java
@@ -19,6 +19,7 @@ public class AdminOrderItemDto {
     private Long itemId;
     private String itemName;
     private Integer itemPrice;
+    private Integer itemQuantity;
     private List<AdminOrderOptionDto> adminOrderOptions = new ArrayList<>();
 
     public static AdminOrderItemDto fromEntity(OrderItem entity) {
@@ -26,6 +27,7 @@ public class AdminOrderItemDto {
                 .itemId(entity.getItem().getId())
                 .itemName(entity.getItem().getName())
                 .itemPrice(entity.getItem().getPrice())
+                .itemQuantity(entity.getQuantity())
                 .adminOrderOptions(entity.getOrderOptions().stream()
                         .map(orderOption -> AdminOrderOptionDto.builder()
                                 .optionId(orderOption.getId())

--- a/src/main/java/com/example/toucheese_be/domain/auth/admin/service/AdminService.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/admin/service/AdminService.java
@@ -6,10 +6,12 @@ import com.example.toucheese_be.domain.auth.admin.dto.AdminOrderOptionDto;
 import com.example.toucheese_be.domain.order.entity.Order;
 import com.example.toucheese_be.domain.order.entity.OrderItem;
 import com.example.toucheese_be.domain.order.repository.OrderRepository;
+import com.example.toucheese_be.domain.studio.dto.PageRequestDto;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties.Admin;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +23,8 @@ public class AdminService {
     /**
      * 예약 리스트 조회
      */
-    public ResponseEntity<List<AdminOrderDto>> readAllOrders() {
-         List<AdminOrderDto> adminOrderDtos = orderRepository.findAllOrdersWithDetails();
+    public ResponseEntity<Page<AdminOrderDto>> readAllOrders(PageRequestDto dto) {
+         Page<AdminOrderDto> adminOrderDtos = orderRepository.findAllOrdersWithDetails(dto);
          return ResponseEntity.ok(adminOrderDtos);
     }
 

--- a/src/main/java/com/example/toucheese_be/domain/auth/admin/service/AdminService.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/admin/service/AdminService.java
@@ -5,20 +5,26 @@ import com.example.toucheese_be.domain.auth.admin.dto.AdminOrderItemDto;
 import com.example.toucheese_be.domain.auth.admin.dto.AdminOrderOptionDto;
 import com.example.toucheese_be.domain.order.entity.Order;
 import com.example.toucheese_be.domain.order.entity.OrderItem;
+import com.example.toucheese_be.domain.order.entity.constant.OrderStatus;
 import com.example.toucheese_be.domain.order.repository.OrderRepository;
 import com.example.toucheese_be.domain.studio.dto.PageRequestDto;
+import com.example.toucheese_be.global.error.ErrorCode;
+import com.example.toucheese_be.global.error.GlobalCustomException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties.Admin;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AdminService {
     private final OrderRepository orderRepository;
+    private final JavaMailSender javaMailSender;
 
     /**
      * 예약 리스트 조회
@@ -28,27 +34,85 @@ public class AdminService {
          return ResponseEntity.ok(adminOrderDtos);
     }
 
-
-    // TODO: 예약 승인
-    public void approveOrder(Long reserveId) {
+    /**
+     * 예약 승인
+     */
+    public ResponseEntity<Boolean> approveOrder(Long orderId) {
         // 에약 정보 찾기 로직
-
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new GlobalCustomException(ErrorCode.ORDER_NOT_FOUND));
         // 예약의 상태를 "승인" 으로 변경 후 저장
+        OrderStatus orderStatus = order.getStatus();
+        if (orderStatus.equals(OrderStatus.KEEP)) {
+            // 예약 승인 email 발송
+            order.setStatus(OrderStatus.SUCCESS);
+            orderRepository.save(order);
+            // 사용자 이메일 가져오기
+            String userEmail = order.getUser().getEmail();
 
-        // 예약 승인 email 발송
+            // 승인 이메일 발송
+            sendEmail(
+                    userEmail,
+                    "[터치즈] 스튜디오 예약이 승인 되었습니다.",
+                    "안녕하세요 터치즈입니다, 고객님. 귀하의 예약이 승인되었습니다. 예약 번호: " + orderId
+            );
 
-        // 반환 ture or false
+            return ResponseEntity.ok(true);
+        } else if (orderStatus.equals(OrderStatus.SUCCESS)) {
+            throw new GlobalCustomException(ErrorCode.ORDER_ALREADY_APPROVED);
+        } else {
+            throw new GlobalCustomException(ErrorCode.ORDER_ALREADY_REJECTED);
+        }
     }
 
 
     // TODO: 예약 거절
-    public void rejectOrder(Long reserveId) {
+    public ResponseEntity<Boolean> rejectOrder(Long orderId) {
         // 에약 정보 찾기 로직
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new GlobalCustomException(ErrorCode.ORDER_NOT_FOUND));
+        // 예약의 상태를 "거절" 으로 변경 후 저장
+        OrderStatus orderStatus = order.getStatus();
+        if (orderStatus.equals(OrderStatus.KEEP)) {
+            // 예약 거절 email 발송
+            order.setStatus(OrderStatus.FAIL);
+            orderRepository.save(order);
+            // 사용자 이메일 가져오기
+            String userEmail = order.getUser().getEmail();
 
-        // 예약 상태를 "거절" 로 변경 후 저장
+            // 승인 이메일 발송
+            sendEmail(
+                    userEmail,
+                    "[터치즈] 스튜디오 예약이 거절 되었습니다.",
+                    "안녕하세요 터치즈입니다, 고객님. 귀하의 예약이 거절되었습니다. 예약 번호: " + orderId
+            );
 
-        // 예약 거절 email 발송
+            return ResponseEntity.ok(true);
+        } else if (orderStatus.equals(OrderStatus.FAIL)) {
+            throw new GlobalCustomException(ErrorCode.ORDER_ALREADY_REJECTED);
+        } else {
+            throw new GlobalCustomException(ErrorCode.ORDER_ALREADY_APPROVED);
+        }
+    }
 
-        // 반환 true or false
+
+
+    /**
+     * 이메일 발송 메서드
+     */
+    private void sendEmail(String to, String subject, String text) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(text);
+            message.setFrom("your-email@example.com"); // 발신 이메일 주소 설정
+            javaMailSender.send(message);
+        } catch (Exception e) {
+            // 이메일 발송 실패 시 로깅
+            e.printStackTrace();
+        }
     }
 }
+
+

--- a/src/main/java/com/example/toucheese_be/domain/auth/user/entity/User.java
+++ b/src/main/java/com/example/toucheese_be/domain/auth/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.toucheese_be.domain.auth.user.entity;
 
+import com.example.toucheese_be.domain.order.entity.Order;
 import com.example.toucheese_be.domain.review.entity.Review;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -27,4 +28,7 @@ public class User {
 
     @Column(length = 150, nullable = false)
     private String email;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Order> orders = new ArrayList<>();
 }

--- a/src/main/java/com/example/toucheese_be/domain/order/entity/Order.java
+++ b/src/main/java/com/example/toucheese_be/domain/order/entity/Order.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 
 @Getter
@@ -34,7 +35,7 @@ public class Order {
     private Studio studio;
 
     // 사용자와 연결
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -48,5 +49,6 @@ public class Order {
 
     // 주문 상품과 연결
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 10)
     private List<OrderItem> orderItems = new ArrayList<>();
 }

--- a/src/main/java/com/example/toucheese_be/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/toucheese_be/domain/order/entity/OrderItem.java
@@ -49,5 +49,6 @@ public class OrderItem {
 
     // 주문 옵션과 연결
     @OneToMany(mappedBy = "orderItem", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 10)
     private List<OrderOption> orderOptions = new ArrayList<>();
 }

--- a/src/main/java/com/example/toucheese_be/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/toucheese_be/domain/order/repository/OrderRepositoryCustom.java
@@ -1,10 +1,12 @@
 package com.example.toucheese_be.domain.order.repository;
 
 import com.example.toucheese_be.domain.auth.admin.dto.AdminOrderDto;
+import com.example.toucheese_be.domain.studio.dto.PageRequestDto;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepositoryCustom {
-    List<AdminOrderDto> findAllOrdersWithDetails();
+    Page<AdminOrderDto> findAllOrdersWithDetails(PageRequestDto dto);
 }

--- a/src/main/java/com/example/toucheese_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/toucheese_be/global/error/ErrorCode.java
@@ -8,7 +8,12 @@ import lombok.Getter;
 public enum ErrorCode {
     // 예외 코드 부분 (추후 작성)
     INVALID_FILTER_PARAMETER(400, "FILTER_INVALID_PARAMETER", "필터링 파라미터가 유효하지 않습니다."),
-    REVIEW_NOT_FOUND(404, "REVIEW_NOT_FOUND", "해당 리뷰를 찾을 수 없습니다.");
+    REVIEW_NOT_FOUND(404, "REVIEW_NOT_FOUND", "해당 리뷰를 찾을 수 없습니다."),
+
+    // 예약 관련 예외 처리
+    ORDER_NOT_FOUND(404, "ORDER_NOT_FOUND", "해당 예약 정보를 찾을 수 없습니다."),
+    ORDER_ALREADY_APPROVED(409, "ORDER_ALREADY_APPROVED", "해당 예약 정보는 이미 승인 되었습니다."),
+    ORDER_ALREADY_REJECTED(409, "ORDER_ALREADY_REJECTED", "해당 예약 정보는 이미 거절 되었습니다.");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 이슈 번호
- ex) #ET-150

### 💡 작업유형
- [x] feature: 신규 기능 추가
- [ ] refactor: 성능 개선 등 리펙토링 및 폴더 구조 정리
- [ ] bug: 버그 수정
- [ ] chores: 변수 이름 or 값, 파일명, 주석 수정, 컨벤션 적용
- [ ] docs: 문서 업데이트(readme, gitignore, PR template 등)

<br>


### 🔑 작업 내역
- 기존 예약 리스트 반환에서 페이지네이션 추가
- User <-> Order 일대다 관계로 수정 (한 사용자가 여러 주문을 생성시킬수있도록)
- 예약 승인 시 승인 처리 및 이메일 발송
- 예약 거절 시 거절 처리 및 이메일 발송



